### PR TITLE
chore: add Husky, Prettier defaults, and eslint-config-prettier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
+          node-version-file: ".nvmrc"
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install --immutable
+
+      - name: Format check
+        run: yarn format:check
 
       - name: Lint
         run: yarn lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 yarn prettier --check .
 yarn eslint src
-tsc -b
+yarn tsc -b
 yarn test --run

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+yarn prettier --check .
+yarn eslint src
+tsc -b
+yarn test --run

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
-node_modules/
-coverage/
-dist/
+dist
+coverage
+.yarn
+*.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,1 @@
-{
-  "trailingComma": "all",
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": true,
-  "printWidth": 120,
-  "bracketSpacing": true,
-  "endOfLine": "lf"
-}
+{}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,26 @@ Config: `.prettierrc` (`{}` — all defaults). Run `yarn format` to reformat, `y
 ## Husky
 
 Pre-commit hook (`.husky/pre-commit`) runs: `prettier --check`, `eslint src`, `tsc -b`, `vitest --run`. Install with `yarn install` (the `prepare` script runs Husky automatically).
+
+## Progress
+
+### Completed
+
+- **PR #4** — initial modernization: Node 24, Vite 6→8, JS→TypeScript (strict), ESLint 9 flat config, Vitest 4, 82 tests, `test.yml` CI, CLAUDE.md, branch protection
+- **PR #5** — follow-up: CODEOWNERS, README, remove unused deps (`test-console`, `eslint-plugin-import`, `eslint-plugin-promise`), delete `tailwind.config.js`, fix `handleNamesChange` throttle, add form tests (83 tests total)
+- **PR #6** — favicon (standard icon set pointing to parent-app assets), remove `eslint-plugin-n`, error-recovery form test, fix `<title>` ordering in `index.html`
+- **PR #7** — delete legacy `.eslintrc.cjs`, fix dev port 5510→3090 in `vite.config.ts`, bump Yarn 4.9.1→4.14.1
+- **PR #8 (open, 2026-05-07)** — Husky pre-commit hook, reset `.prettierrc` to `{}` (Prettier defaults), add `eslint-config-prettier`, remove `@stylistic/eslint-plugin-js`, add `format`/`format:check` scripts, `format:check` step in CI, full reformat
+
+### Outstanding
+
+- Merge PR #8 and confirm CI passes — after that, `order` is fully aligned with the cross-repo standard
+- No further planned changes specific to this repo
+
+### Key decisions
+
+- `.prettierrc` is `{}` — Prettier defaults apply (double quotes, 80-char print width, `trailingComma: "all"`); single quotes used previously are gone
+- `eslint-config-prettier` is the last entry in `eslint.config.mjs` — disables all ESLint rules that could conflict with Prettier formatting
+- `@stylistic/eslint-plugin-js` removed — was imported but no rules were actually using the `@stylistic/js/` prefix; formatting is Prettier's job
+- Husky hook uses `yarn tsc -b` (not bare `tsc -b`) — bare command relies on a global TypeScript install; `yarn` prefix resolves from `node_modules/.bin/`
+- `lint` script has no `--fix` flag — intentional; fixes must be deliberate, not automatic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,8 @@ yarn dev          # Start dev server at http://localhost:3090
 yarn build        # Type-check (tsc -b) then build to dist/
 yarn preview      # Preview the production build locally
 yarn lint         # ESLint on src/
+yarn format       # Prettier --write on all files
+yarn format:check # Prettier --check (used in CI)
 yarn test         # Vitest in watch mode
 yarn test:run     # Vitest single pass
 yarn coverage     # Vitest with coverage report
@@ -21,6 +23,7 @@ yarn coverage     # Vitest with coverage report
 A single-page React 19 + TypeScript app (Vite 8) that generates a randomized speaking order from a list of participant names.
 
 **Data flow:**
+
 1. `Form` collects participant names from a textarea, and optionally saves the list to `localStorage` via the "Remember this list" switch.
 2. Submitting the form calls `parseNames()` on the textarea value, then stores the result in `NamesContext` via `setCurrentNames`.
 3. `Results` reads `currentNames` from context, calls `generate()` (which shuffles the names and joins them with configured separators), and displays the output.
@@ -30,6 +33,7 @@ A single-page React 19 + TypeScript app (Vite 8) that generates a randomized spe
 **Context:** `NamesContext` / `NamesProvider` hold a single piece of state: `currentNames: INamesEntry | null` (`{ id: string | null; names: string[] }`). The `id` is a UUID that links a set of names to a `localStorage` key.
 
 **Core utilities — `src/utils/index.ts`:**
+
 - `parseNames(text)` — parses comma/space-delimited input; quoted strings with spaces (e.g. `"Jane Doe"`) are preserved as a single name.
 - `shuffle<T>(array)` — Fisher-Yates in-place shuffle on a copy.
 - `joinAnd(array, options)` — joins an array with a separator and last separator, with optional Oxford comma.
@@ -56,5 +60,12 @@ Icons are Font Awesome Light (`fal`) from a private kit (`@awesome.me/kit-84f13f
 
 ## ESLint
 
-Config: `eslint.config.mjs` (ESLint 9 flat config, `typescript-eslint` recommended rules). Run `yarn lint` — no auto-fix flag, intentional.
+Config: `eslint.config.mjs` (ESLint 9 flat config, `typescript-eslint` recommended rules). Formatting rules are delegated to Prettier via `eslint-config-prettier`. Run `yarn lint` — no auto-fix flag, intentional.
 
+## Prettier
+
+Config: `.prettierrc` (`{}`— all defaults). Run `yarn format` to reformat, `yarn format:check` to verify. The pre-commit hook runs `format:check` before committing.
+
+## Husky
+
+Pre-commit hook (`.husky/pre-commit`) runs: `prettier --check`, `eslint src`, `tsc -b`, `vitest --run`. Install with `yarn install` (the `prepare` script runs Husky automatically).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Config: `eslint.config.mjs` (ESLint 9 flat config, `typescript-eslint` recommend
 
 ## Prettier
 
-Config: `.prettierrc` (`{}`— all defaults). Run `yarn format` to reformat, `yarn format:check` to verify. The pre-commit hook runs `format:check` before committing.
+Config: `.prettierrc` (`{}` — all defaults). Run `yarn format` to reformat, `yarn format:check` to verify. The pre-commit hook runs `format:check` before committing.
 
 ## Husky
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,17 @@ Requires Node 24 and Yarn 4. A `FONTAWESOME_NPM_AUTH_TOKEN` environment variable
 
 ```bash
 yarn install
-yarn dev       # start dev server
-yarn lint      # ESLint (no auto-fix)
-yarn test      # Vitest in watch mode
-yarn test:run  # single-pass test run
-yarn coverage  # coverage report
-yarn build     # type-check then build to dist/
+yarn dev          # start dev server
+yarn lint         # ESLint (no auto-fix)
+yarn format       # Prettier (write)
+yarn format:check # Prettier (check only, used in CI)
+yarn test         # Vitest in watch mode
+yarn test:run     # single-pass test run
+yarn coverage     # coverage report
+yarn build        # type-check then build to dist/
 ```
+
+A Husky pre-commit hook runs `prettier --check`, `eslint`, `tsc -b`, and `vitest --run` on every commit.
 
 ## Deployment
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,15 +1,15 @@
-import globals from 'globals';
-import js from '@eslint/js';
-import tseslint from 'typescript-eslint';
-import stylisticJs from '@stylistic/eslint-plugin-js';
-import pluginReact from 'eslint-plugin-react';
-import reactHooks from 'eslint-plugin-react-hooks';
-import jsxA11y from 'eslint-plugin-jsx-a11y';
+import globals from "globals";
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import pluginReact from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+import prettierConfig from "eslint-config-prettier";
 
 export default tseslint.config(
   {
     settings: {
-      react: { version: 'detect' },
+      react: { version: "detect" },
     },
     languageOptions: {
       globals: globals.browser,
@@ -18,29 +18,26 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-  reactHooks.configs['recommended-latest'],
+  reactHooks.configs["recommended-latest"],
   jsxA11y.flatConfigs.recommended,
   {
-    plugins: {
-      '@stylistic/js': stylisticJs,
-    },
     rules: {
-      'indent': ['error', 2, { SwitchCase: 1 }],
-      'jsx-quotes': ['error', 'prefer-double'],
-      'object-curly-spacing': ['error', 'always'],
-      'semi': 'error',
-      'no-console': ['warn', { allow: ['error'] }],
-      'no-nested-ternary': 'warn',
-      'no-use-before-define': ['error', { functions: false, classes: true, variables: true }],
-      'react/no-array-index-key': 'error',
-      'react/no-danger': 'error',
-      'react/react-in-jsx-scope': 0,
-      'react/jsx-uses-react': 0,
-      'jsx-a11y/no-autofocus': 'warn',
-      '@typescript-eslint/no-explicit-any': 'warn',
+      "no-console": ["warn", { allow: ["error"] }],
+      "no-nested-ternary": "warn",
+      "no-use-before-define": [
+        "error",
+        { functions: false, classes: true, variables: true },
+      ],
+      "react/no-array-index-key": "error",
+      "react/no-danger": "error",
+      "react/react-in-jsx-scope": 0,
+      "react/jsx-uses-react": 0,
+      "jsx-a11y/no-autofocus": "warn",
+      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
+  prettierConfig,
   {
-    ignores: ['node_modules', 'dist', 'coverage'],
+    ignores: ["node_modules", "dist", "coverage"],
   },
 );

--- a/index.html
+++ b/index.html
@@ -1,37 +1,69 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Generate Speaking Order</title>
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/apple-touch-icon.png?v=wAdO0d8bp8"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/favicon-32x32.png?v=wAdO0d8bp8"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="194x194"
+      href="/favicon-194x194.png?v=wAdO0d8bp8"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="192x192"
+      href="/android-chrome-192x192.png?v=wAdO0d8bp8"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/favicon-16x16.png?v=wAdO0d8bp8"
+    />
+    <link rel="manifest" href="/site.webmanifest?v=wAdO0d8bp8" />
+    <link
+      rel="mask-icon"
+      href="/safari-pinned-tab.svg?v=wAdO0d8bp8"
+      color="#005b99"
+    />
+    <link rel="shortcut icon" href="/favicon.ico?v=wAdO0d8bp8" />
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Generate Speaking Order</title>
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=wAdO0d8bp8" />
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=wAdO0d8bp8" />
-  <link rel="icon" type="image/png" sizes="194x194" href="/favicon-194x194.png?v=wAdO0d8bp8" />
-  <link rel="icon" type="image/png" sizes="192x192" href="/android-chrome-192x192.png?v=wAdO0d8bp8" />
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=wAdO0d8bp8" />
-  <link rel="manifest" href="/site.webmanifest?v=wAdO0d8bp8" />
-  <link rel="mask-icon" href="/safari-pinned-tab.svg?v=wAdO0d8bp8" color="#005b99" />
-  <link rel="shortcut icon" href="/favicon.ico?v=wAdO0d8bp8" />
+    <script>
+      (() =>
+        !window.location.pathname.endsWith("/") &&
+        window.location.replace(window.location.href + "/"))();
 
-  <script>
-    (() => !window.location.pathname.endsWith("/") && window.location.replace(window.location.href + "/"))()
+      // https://tailwindcss.com/docs/dark-mode#supporting-system-preference-and-manual-selection
+      // On page load or when changing themes, best to add inline in `head` to avoid FOUC
+      if (
+        (localStorage.theme &&
+          typeof localStorage.theme === "string" &&
+          JSON.parse(localStorage.theme) === "dark") ||
+        (!("theme" in localStorage) &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches)
+      ) {
+        document.documentElement.classList.add("dark");
+      } else {
+        document.documentElement.classList.remove("dark");
+      }
+    </script>
+  </head>
 
-    // https://tailwindcss.com/docs/dark-mode#supporting-system-preference-and-manual-selection
-    // On page load or when changing themes, best to add inline in `head` to avoid FOUC
-    if ((localStorage.theme && typeof localStorage.theme === "string" && JSON.parse(localStorage.theme) === 'dark')
-      || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)
-    ) {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-  </script>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.jsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -13,9 +13,12 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint src",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "vitest",
     "test:run": "vitest run",
-    "coverage": "vitest run --coverage"
+    "coverage": "vitest run --coverage",
+    "prepare": "husky"
   },
   "dependencies": {
     "@awesome.me/kit-84f13ff524": "^1.0.7",
@@ -30,7 +33,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.24.0",
-    "@stylistic/eslint-plugin-js": "^4.2.0",
     "@tailwindcss/vite": "^4.2.4",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -42,10 +44,12 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9.24.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "globals": "^16.0.0",
+    "husky": "^9.1.7",
     "jsdom": "^29.1.0",
     "prettier": "^3.5.3",
     "tailwindcss": "^4.2.4",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,21 +1,21 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-describe('App component', () => {
-  it('renders without crashing', () => {
+describe("App component", () => {
+  it("renders without crashing", () => {
     render(<App />);
   });
 
-  it('renders the Header component', () => {
+  it("renders the Header component", () => {
     render(<App />);
     const headerElement = screen.getByText(/Generate Speaking Order/i);
     expect(headerElement).toBeInTheDocument();
   });
 
-  it('renders the Form component', () => {
+  it("renders the Form component", () => {
     render(<App />);
-    const formElement = screen.getByRole('form');
+    const formElement = screen.getByRole("form");
     expect(formElement).toBeInTheDocument();
   });
 
@@ -25,9 +25,9 @@ describe('App component', () => {
   //     expect(resultsElement).toBeInTheDocument();
   //   });
 
-  it('renders the Aside component', () => {
+  it("renders the Aside component", () => {
     render(<App />);
-    const toggleButton = screen.getByLabelText('Open settings menu');
+    const toggleButton = screen.getByLabelText("Open settings menu");
     expect(toggleButton).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,9 @@
-import NamesProvider from './contexts/NamesProvider';
-import Header from './components/Header';
-import Form from './components/Form';
-import Results from './components/Results';
-import Aside from './components/Aside/Aside';
-import ConfirmDialog from './components/StoredNames/ConfirmDialog';
+import NamesProvider from "./contexts/NamesProvider";
+import Header from "./components/Header";
+import Form from "./components/Form";
+import Results from "./components/Results";
+import Aside from "./components/Aside/Aside";
+import ConfirmDialog from "./components/StoredNames/ConfirmDialog";
 
 function App() {
   return (
@@ -11,7 +11,7 @@ function App() {
       <ConfirmDialog />
       <NamesProvider>
         <main className="container max-w-lg min-w-min mx-auto my-4 px-4">
-          <Header title={'Generate Speaking Order'} />
+          <Header title={"Generate Speaking Order"} />
 
           <Form />
 

--- a/src/components/Aside/Aside.test.tsx
+++ b/src/components/Aside/Aside.test.tsx
@@ -1,9 +1,9 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import Aside from './Aside';
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Aside from "./Aside";
 
-describe('Aside component', () => {
-  it('renders without crashing', () => {
+describe("Aside component", () => {
+  it("renders without crashing", () => {
     render(<Aside />);
   });
 

--- a/src/components/Aside/Aside.tsx
+++ b/src/components/Aside/Aside.tsx
@@ -1,14 +1,14 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useMediaQuery } from '@uidotdev/usehooks';
-import { Transition } from '@headlessui/react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { byPrefixAndName } from '@awesome.me/kit-84f13ff524/icons';
-import StoredNames from '../StoredNames/StoredNames';
-import Settings from './Settings';
+import { useCallback, useEffect, useState } from "react";
+import { useMediaQuery } from "@uidotdev/usehooks";
+import { Transition } from "@headlessui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { byPrefixAndName } from "@awesome.me/kit-84f13ff524/icons";
+import StoredNames from "../StoredNames/StoredNames";
+import Settings from "./Settings";
 
 function Aside() {
   const [offCanvas, setOffCanvas] = useState(false);
-  const mdBreakpoint = useMediaQuery('(min-width: 768px)');
+  const mdBreakpoint = useMediaQuery("(min-width: 768px)");
 
   const closeOffCanvas = () => {
     if (mdBreakpoint) return;
@@ -29,10 +29,10 @@ function Aside() {
   }, [fixOffCanvas]);
 
   useEffect(() => {
-    window.addEventListener('resize', fixOffCanvas);
+    window.addEventListener("resize", fixOffCanvas);
 
     return () => {
-      window.removeEventListener('resize', fixOffCanvas);
+      window.removeEventListener("resize", fixOffCanvas);
     };
   }, [fixOffCanvas]);
 
@@ -45,7 +45,11 @@ function Aside() {
           onClick={toggleOffCanvas}
           aria-label="Open settings menu"
         >
-          <FontAwesomeIcon icon={byPrefixAndName.fal['bars']} size="lg" fixedWidth />
+          <FontAwesomeIcon
+            icon={byPrefixAndName.fal["bars"]}
+            size="lg"
+            fixedWidth
+          />
         </button>
       </div>
 
@@ -65,7 +69,10 @@ function Aside() {
           <div className="w-80">
             <div className="flex justify-between items-center border-b border-slate-400 p-4">
               <h2 className="font-extralight uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                <FontAwesomeIcon icon={byPrefixAndName.fal['list']} className="me-2" />
+                <FontAwesomeIcon
+                  icon={byPrefixAndName.fal["list"]}
+                  className="me-2"
+                />
                 Stored lists
               </h2>
 
@@ -75,7 +82,11 @@ function Aside() {
                 onClick={toggleOffCanvas}
                 aria-label="Close settings menu"
               >
-                <FontAwesomeIcon icon={byPrefixAndName.fal['xmark']} size="lg" fixedWidth />
+                <FontAwesomeIcon
+                  icon={byPrefixAndName.fal["xmark"]}
+                  size="lg"
+                  fixedWidth
+                />
               </button>
             </div>
 

--- a/src/components/Aside/Settings.test.tsx
+++ b/src/components/Aside/Settings.test.tsx
@@ -1,18 +1,18 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import Settings from './Settings';
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Settings from "./Settings";
 
-describe('Settings', () => {
-  it('renders the Settings component correctly', () => {
+describe("Settings", () => {
+  it("renders the Settings component correctly", () => {
     render(<Settings />);
 
-    expect(screen.getByText('Settings')).toBeInTheDocument();
-    expect(screen.getByLabelText('Prefix')).toBeInTheDocument();
-    expect(screen.getByLabelText('Separator')).toBeInTheDocument();
-    expect(screen.getByLabelText('Last separator')).toBeInTheDocument();
-    expect(screen.getByText('Appearance')).toBeInTheDocument();
-    expect(screen.getByLabelText('Dark')).toBeInTheDocument();
-    expect(screen.getByLabelText('Light')).toBeInTheDocument();
-    expect(screen.getByLabelText('System')).toBeInTheDocument();
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByLabelText("Prefix")).toBeInTheDocument();
+    expect(screen.getByLabelText("Separator")).toBeInTheDocument();
+    expect(screen.getByLabelText("Last separator")).toBeInTheDocument();
+    expect(screen.getByText("Appearance")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dark")).toBeInTheDocument();
+    expect(screen.getByLabelText("Light")).toBeInTheDocument();
+    expect(screen.getByLabelText("System")).toBeInTheDocument();
   });
 });

--- a/src/components/Aside/Settings.tsx
+++ b/src/components/Aside/Settings.tsx
@@ -1,30 +1,39 @@
-import { useEffect } from 'react';
-import { useLocalStorage, useMediaQuery } from '@uidotdev/usehooks';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { byPrefixAndName } from '@awesome.me/kit-84f13ff524/icons';
-import { DEFAULT_OPTIONS } from '../../utils/constants';
-import type { IOptions } from '../../utils/constants';
-import Switch from '../Fields/Switch';
+import { useEffect } from "react";
+import { useLocalStorage, useMediaQuery } from "@uidotdev/usehooks";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { byPrefixAndName } from "@awesome.me/kit-84f13ff524/icons";
+import { DEFAULT_OPTIONS } from "../../utils/constants";
+import type { IOptions } from "../../utils/constants";
+import Switch from "../Fields/Switch";
 
 function Settings() {
-  const [storedOptions, setStoredOptions] = useLocalStorage<Partial<IOptions> | null>('options', null);
-  const [storedTheme, setStoredTheme] = useLocalStorage<string | undefined>('theme', undefined);
-  const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
-  const localOptions = storedOptions ? { ...DEFAULT_OPTIONS, ...storedOptions } : DEFAULT_OPTIONS;
+  const [storedOptions, setStoredOptions] =
+    useLocalStorage<Partial<IOptions> | null>("options", null);
+  const [storedTheme, setStoredTheme] = useLocalStorage<string | undefined>(
+    "theme",
+    undefined,
+  );
+  const prefersDark = useMediaQuery("(prefers-color-scheme: dark)");
+  const localOptions = storedOptions
+    ? { ...DEFAULT_OPTIONS, ...storedOptions }
+    : DEFAULT_OPTIONS;
 
   useEffect(() => {
     if (!storedTheme) {
       if (prefersDark) {
-        document.documentElement.classList.add('dark');
+        document.documentElement.classList.add("dark");
       } else {
-        document.documentElement.classList.remove('dark');
+        document.documentElement.classList.remove("dark");
       }
     }
   }, [prefersDark, storedTheme]);
 
   const handleSettingsChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.type === 'checkbox') {
-      setStoredOptions((prev) => ({ ...prev, [e.target.name]: e.target.checked }));
+    if (e.target.type === "checkbox") {
+      setStoredOptions((prev) => ({
+        ...prev,
+        [e.target.name]: e.target.checked,
+      }));
       return;
     }
     setStoredOptions((prev) => ({ ...prev, [e.target.name]: e.target.value }));
@@ -33,14 +42,22 @@ function Settings() {
   const handleThemeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { checked, value } = e.target;
     if (checked) {
-      setStoredTheme(value === 'system' ? undefined : value);
+      setStoredTheme(value === "system" ? undefined : value);
 
-      if (value === 'light' || (value === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches)) {
-        document.documentElement.classList.remove('dark');
+      if (
+        value === "light" ||
+        (value === "system" &&
+          window.matchMedia("(prefers-color-scheme: light)").matches)
+      ) {
+        document.documentElement.classList.remove("dark");
       }
 
-      if (value === 'dark' || (value === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.classList.add('dark');
+      if (
+        value === "dark" ||
+        (value === "system" &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches)
+      ) {
+        document.documentElement.classList.add("dark");
       }
     }
   };
@@ -48,12 +65,15 @@ function Settings() {
   return (
     <>
       <h2 className="border-b border-slate-400 py-5 px-4 font-extralight uppercase tracking-wide text-slate-600 dark:text-slate-400">
-        <FontAwesomeIcon icon={byPrefixAndName.fal['cog']} className="me-2" />
+        <FontAwesomeIcon icon={byPrefixAndName.fal["cog"]} className="me-2" />
         Settings
       </h2>
       <div className="p-4">
         <div>
-          <label htmlFor="prefix" className="block text-sm text-slate-600 dark:text-slate-400">
+          <label
+            htmlFor="prefix"
+            className="block text-sm text-slate-600 dark:text-slate-400"
+          >
             Prefix
           </label>
           <input
@@ -67,7 +87,9 @@ function Settings() {
         </div>
 
         <div>
-          <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">Separators</p>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+            Separators
+          </p>
           <label htmlFor="separator" className="sr-only">
             Separator
           </label>
@@ -93,14 +115,22 @@ function Settings() {
         </div>
 
         <div className="mt-1">
-          <Switch name="oxfordComma" checked={!!localOptions.oxfordComma} value="1" onChange={handleSettingsChange} />
+          <Switch
+            name="oxfordComma"
+            checked={!!localOptions.oxfordComma}
+            value="1"
+            onChange={handleSettingsChange}
+          />
         </div>
       </div>
 
       <div className="mt-3 border-t border-slate-400">
         <div className="p-4">
           <h3 className="mb-1 font-light tracking-wide text-slate-600 dark:text-slate-400">
-            <FontAwesomeIcon icon={byPrefixAndName.fal['eclipse']} className="me-2" />
+            <FontAwesomeIcon
+              icon={byPrefixAndName.fal["eclipse"]}
+              className="me-2"
+            />
             Appearance
           </h3>
 
@@ -110,7 +140,7 @@ function Settings() {
               id="theme-dark"
               name="theme"
               value="dark"
-              defaultChecked={storedTheme === 'dark'}
+              defaultChecked={storedTheme === "dark"}
               className="me-1"
               onChange={handleThemeChange}
             />
@@ -123,7 +153,7 @@ function Settings() {
               id="theme-light"
               name="theme"
               value="light"
-              defaultChecked={storedTheme === 'light'}
+              defaultChecked={storedTheme === "light"}
               className="me-1"
               onChange={handleThemeChange}
             />
@@ -136,7 +166,7 @@ function Settings() {
               id="theme-system"
               name="theme"
               value="system"
-              defaultChecked={storedTheme === 'system' || !storedTheme}
+              defaultChecked={storedTheme === "system" || !storedTheme}
               className="me-1"
               onChange={handleThemeChange}
             />

--- a/src/components/CopyButton.test.tsx
+++ b/src/components/CopyButton.test.tsx
@@ -1,13 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
-import CopyButton from './CopyButton';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import CopyButton from "./CopyButton";
 
-Object.defineProperty(globalThis.navigator, 'clipboard', {
+Object.defineProperty(globalThis.navigator, "clipboard", {
   value: { writeText: vi.fn().mockResolvedValue(undefined) },
   configurable: true,
 });
 
-describe('CopyButton component', () => {
+describe("CopyButton component", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.mocked(globalThis.navigator.clipboard.writeText).mockClear();
@@ -17,42 +17,56 @@ describe('CopyButton component', () => {
     vi.useRealTimers();
   });
 
-  it('renders without crashing', () => {
+  it("renders without crashing", () => {
     render(<CopyButton text="hello" />);
   });
 
-  it('renders the copy icon initially', () => {
+  it("renders the copy icon initially", () => {
     render(<CopyButton text="hello" />);
-    expect(screen.getByTestId('copy-button-icon')).toHaveAttribute('data-icon', 'copy');
+    expect(screen.getByTestId("copy-button-icon")).toHaveAttribute(
+      "data-icon",
+      "copy",
+    );
   });
 
-  it('copies text to clipboard when clicked', async () => {
+  it("copies text to clipboard when clicked", async () => {
     render(<CopyButton text="hello world" />);
-    fireEvent.click(screen.getByRole('button', { name: /copy/i }));
-    expect(globalThis.navigator.clipboard.writeText).toHaveBeenCalledWith('hello world');
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    expect(globalThis.navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "hello world",
+    );
   });
 
-  it('shows check icon after clicking', async () => {
+  it("shows check icon after clicking", async () => {
     render(<CopyButton text="hello" />);
-    fireEvent.click(screen.getByRole('button', { name: /copy/i }));
-    expect(screen.getByTestId('copy-button-icon')).toHaveAttribute('data-icon', 'circle-check');
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    expect(screen.getByTestId("copy-button-icon")).toHaveAttribute(
+      "data-icon",
+      "circle-check",
+    );
   });
 
-  it('reverts to copy icon after timeout', async () => {
+  it("reverts to copy icon after timeout", async () => {
     render(<CopyButton text="hello" />);
-    fireEvent.click(screen.getByRole('button', { name: /copy/i }));
-    expect(screen.getByTestId('copy-button-icon')).toHaveAttribute('data-icon', 'circle-check');
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    expect(screen.getByTestId("copy-button-icon")).toHaveAttribute(
+      "data-icon",
+      "circle-check",
+    );
 
     await act(async () => {
       vi.advanceTimersByTime(600);
     });
 
-    expect(screen.getByTestId('copy-button-icon')).toHaveAttribute('data-icon', 'copy');
+    expect(screen.getByTestId("copy-button-icon")).toHaveAttribute(
+      "data-icon",
+      "copy",
+    );
   });
 
-  it('handles null text gracefully', () => {
+  it("handles null text gracefully", () => {
     render(<CopyButton text={null} />);
-    fireEvent.click(screen.getByRole('button', { name: /copy/i }));
-    expect(globalThis.navigator.clipboard.writeText).toHaveBeenCalledWith('');
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }));
+    expect(globalThis.navigator.clipboard.writeText).toHaveBeenCalledWith("");
   });
 });

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,18 +1,18 @@
-import { useState } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { byPrefixAndName } from '@awesome.me/kit-84f13ff524/icons';
-import { copyToClipboard } from '../utils';
+import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { byPrefixAndName } from "@awesome.me/kit-84f13ff524/icons";
+import { copyToClipboard } from "../utils";
 
 interface ICopyButtonProps {
   text: string | null;
 }
 
-function CopyButton({ text = '' }: ICopyButtonProps) {
+function CopyButton({ text = "" }: ICopyButtonProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = (e: React.MouseEvent<HTMLButtonElement>) => {
     const copyButton = e.currentTarget;
-    copyToClipboard(text ?? '');
+    copyToClipboard(text ?? "");
     setCopied(true);
     setTimeout(() => {
       copyButton.blur();
@@ -27,14 +27,18 @@ function CopyButton({ text = '' }: ICopyButtonProps) {
         invisible group-hover:visible group-focus-within:visible
         mt-1 mr-1 p-1 rounded-sm
         bg-white dark:bg-slate-900 bg-opacity-75 dark:bg-opacity-50 backdrop-blur-sm
-        ${copied ? 'text-green-600 dark:text-green-400 focus-visible:outline-green-800/50' : 'text-slate-600 dark:text-slate-400 focus-visible:outline-orange-500/50'}
+        ${copied ? "text-green-600 dark:text-green-400 focus-visible:outline-green-800/50" : "text-slate-600 dark:text-slate-400 focus-visible:outline-orange-500/50"}
         transition-colors duration-100
       `}
       type="button"
       title="Copy"
       onClick={handleCopy}
     >
-      <FontAwesomeIcon data-testid="copy-button-icon" icon={byPrefixAndName.fal[copied ? 'check-circle' : 'copy']} fixedWidth />
+      <FontAwesomeIcon
+        data-testid="copy-button-icon"
+        icon={byPrefixAndName.fal[copied ? "check-circle" : "copy"]}
+        fixedWidth
+      />
     </button>
   );
 }

--- a/src/components/Fields/Switch.test.tsx
+++ b/src/components/Fields/Switch.test.tsx
@@ -1,42 +1,42 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import _kebabCase from 'lodash/kebabCase';
-import Switch from './Switch';
-import { sentenceCase } from '../../utils';
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import _kebabCase from "lodash/kebabCase";
+import Switch from "./Switch";
+import { sentenceCase } from "../../utils";
 
-describe('Switch component', () => {
-  it('renders without crashing', () => {
+describe("Switch component", () => {
+  it("renders without crashing", () => {
     render(<Switch name="test" />);
   });
 
-  it('renders the label', () => {
-    const name = 'test';
+  it("renders the label", () => {
+    const name = "test";
     render(<Switch name={name} />);
     const labelElement = screen.getByText(sentenceCase(name));
     expect(labelElement).toBeInTheDocument();
   });
 
-  it('changes state when clicked', () => {
-    const name = 'test';
+  it("changes state when clicked", () => {
+    const name = "test";
     render(<Switch name={name} />);
-    const inputElement = screen.getByRole('checkbox') as HTMLInputElement;
+    const inputElement = screen.getByRole("checkbox") as HTMLInputElement;
     expect(inputElement.checked).toEqual(false);
     fireEvent.click(inputElement);
     expect(inputElement.checked).toEqual(true);
   });
 
-  it('has the correct id', () => {
-    const id = 'test-id';
-    const name = 'test-name';
+  it("has the correct id", () => {
+    const id = "test-id";
+    const name = "test-name";
     render(<Switch id={id} name={name} />);
-    const inputElement = screen.getByRole('checkbox');
-    expect(inputElement).toHaveAttribute('id', id);
+    const inputElement = screen.getByRole("checkbox");
+    expect(inputElement).toHaveAttribute("id", id);
   });
 
-  it('generates id from name if id is not provided', () => {
-    const name = 'test-name';
+  it("generates id from name if id is not provided", () => {
+    const name = "test-name";
     render(<Switch name={name} />);
-    const inputElement = screen.getByRole('checkbox');
-    expect(inputElement).toHaveAttribute('id', _kebabCase(name));
+    const inputElement = screen.getByRole("checkbox");
+    expect(inputElement).toHaveAttribute("id", _kebabCase(name));
   });
 });

--- a/src/components/Fields/Switch.tsx
+++ b/src/components/Fields/Switch.tsx
@@ -1,8 +1,9 @@
-import type { InputHTMLAttributes } from 'react';
-import _kebabCase from 'lodash/kebabCase';
-import { sentenceCase } from '../../utils';
+import type { InputHTMLAttributes } from "react";
+import _kebabCase from "lodash/kebabCase";
+import { sentenceCase } from "../../utils";
 
-interface ISwitchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'id'> {
+interface ISwitchProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, "id"> {
   id?: string | null;
   name: string;
   label?: string | null;
@@ -10,7 +11,14 @@ interface ISwitchProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'id'>
   value?: string | number;
 }
 
-function Switch({ id = null, name, label = null, checked = false, value = 'on', ...props }: ISwitchProps) {
+function Switch({
+  id = null,
+  name,
+  label = null,
+  checked = false,
+  value = "on",
+  ...props
+}: ISwitchProps) {
   const derivedId = id || _kebabCase(name);
   const derivedLabel = label || sentenceCase(name);
 
@@ -26,7 +34,9 @@ function Switch({ id = null, name, label = null, checked = false, value = 'on', 
         {...props}
       />
       <div className="relative w-7 h-4 bg-slate-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-slate-200/50 peer-focus:peer-checked:ring-green-500/50 dark:peer-focus:ring-green-800 rounded-full peer dark:bg-slate-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white dark:after:bg-slate-300 dark:after:peer-checked:bg-white/50 after:border-slate-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all dark:border-slate-600 peer-checked:bg-green-600"></div>
-      <span className="ms-2 text-sm text-slate-600 dark:text-slate-400">{derivedLabel}</span>
+      <span className="ms-2 text-sm text-slate-600 dark:text-slate-400">
+        {derivedLabel}
+      </span>
     </label>
   );
 }

--- a/src/components/Fields/Textarea.test.tsx
+++ b/src/components/Fields/Textarea.test.tsx
@@ -1,48 +1,54 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import _kebabCase from 'lodash/kebabCase';
-import Textarea from './Textarea';
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import _kebabCase from "lodash/kebabCase";
+import Textarea from "./Textarea";
 
-describe('Textarea component', () => {
-  it('renders without crashing', () => {
+describe("Textarea component", () => {
+  it("renders without crashing", () => {
     render(<Textarea />);
   });
 
-  it('has the correct id', () => {
-    const id = 'test-id';
-    const name = 'test-name';
+  it("has the correct id", () => {
+    const id = "test-id";
+    const name = "test-name";
     render(<Textarea id={id} name={name} />);
-    const textareaElement = screen.getByRole('textbox');
-    expect(textareaElement).toHaveAttribute('id', id);
+    const textareaElement = screen.getByRole("textbox");
+    expect(textareaElement).toHaveAttribute("id", id);
   });
 
-  it('generates id from name if id is not provided', () => {
-    const name = 'test-name';
+  it("generates id from name if id is not provided", () => {
+    const name = "test-name";
     render(<Textarea name={name} />);
-    const textareaElement = screen.getByRole('textbox');
-    expect(textareaElement).toHaveAttribute('id', _kebabCase(name));
+    const textareaElement = screen.getByRole("textbox");
+    expect(textareaElement).toHaveAttribute("id", _kebabCase(name));
   });
 
-  it('resizes on input when autoResize prop is true', () => {
+  it("resizes on input when autoResize prop is true", () => {
     render(<Textarea autoResize={true} name="test" />);
-    const textarea = screen.getByRole('textbox');
+    const textarea = screen.getByRole("textbox");
     const initialHeight = textarea.style.height;
 
     fireEvent.input(textarea, {
-      target: { value: 'A very long text that should trigger the auto resize feature of the textarea component.' },
+      target: {
+        value:
+          "A very long text that should trigger the auto resize feature of the textarea component.",
+      },
     });
 
     const finalHeight = textarea.style.height;
     expect(finalHeight).not.toBe(initialHeight);
   });
 
-  it('does not resize on input when autoResize prop is false', () => {
+  it("does not resize on input when autoResize prop is false", () => {
     render(<Textarea autoResize={false} name="test" />);
-    const textarea = screen.getByRole('textbox');
+    const textarea = screen.getByRole("textbox");
     const initialHeight = textarea.style.height;
 
     fireEvent.input(textarea, {
-      target: { value: 'A very long text that should not trigger the auto resize feature of the textarea component.' },
+      target: {
+        value:
+          "A very long text that should not trigger the auto resize feature of the textarea component.",
+      },
     });
 
     const finalHeight = textarea.style.height;

--- a/src/components/Fields/Textarea.tsx
+++ b/src/components/Fields/Textarea.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef } from 'react';
-import type { TextareaHTMLAttributes, RefObject } from 'react';
-import _kebabCase from 'lodash/kebabCase';
+import { useEffect, useRef } from "react";
+import type { TextareaHTMLAttributes, RefObject } from "react";
+import _kebabCase from "lodash/kebabCase";
 
-interface ITextareaProps extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, 'id'> {
+interface ITextareaProps
+  extends Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "id"> {
   id?: string | null;
   name?: string;
   autoResize?: boolean;
@@ -13,11 +14,18 @@ const HEIGHT_ADJUSTMENT_OFFSET = 2;
 
 const resizeInput = (e: Event) => {
   const el = e.target as HTMLTextAreaElement;
-  el.style.height = 'auto';
+  el.style.height = "auto";
   el.style.height = `${el.scrollHeight + HEIGHT_ADJUSTMENT_OFFSET}px`;
 };
 
-function Textarea({ id = null, name, className = '', autoResize = false, innerRef = null, ...props }: ITextareaProps) {
+function Textarea({
+  id = null,
+  name,
+  className = "",
+  autoResize = false,
+  innerRef = null,
+  ...props
+}: ITextareaProps) {
   const derivedId = id || (name ? _kebabCase(name) : undefined);
   const ref = useRef<HTMLTextAreaElement>(null);
   const thisRef = innerRef || ref;
@@ -26,14 +34,22 @@ function Textarea({ id = null, name, className = '', autoResize = false, innerRe
     if (!autoResize || !thisRef.current) return;
 
     const el = thisRef.current;
-    el.addEventListener('input', resizeInput);
+    el.addEventListener("input", resizeInput);
 
     return () => {
-      el.removeEventListener('input', resizeInput);
+      el.removeEventListener("input", resizeInput);
     };
   }, [autoResize, thisRef]);
 
-  return <textarea ref={thisRef} id={derivedId} name={name} className={className} {...props} />;
+  return (
+    <textarea
+      ref={thisRef}
+      id={derivedId}
+      name={name}
+      className={className}
+      {...props}
+    />
+  );
 }
 
 export default Textarea;

--- a/src/components/Form.test.tsx
+++ b/src/components/Form.test.tsx
@@ -1,27 +1,27 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { NamesContext } from '../contexts/NamesContext';
-import { parseNames } from '../utils';
-import Form from './Form';
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NamesContext } from "../contexts/NamesContext";
+import { parseNames } from "../utils";
+import Form from "./Form";
 
-describe('Form component', () => {
-  it('renders without crashing', () => {
+describe("Form component", () => {
+  it("renders without crashing", () => {
     render(<Form />);
   });
 
-  it('displays the current names in the textarea', () => {
-    const currentNames = { id: '1', names: ['John', 'Jane', 'Doe'] };
+  it("displays the current names in the textarea", () => {
+    const currentNames = { id: "1", names: ["John", "Jane", "Doe"] };
     render(
       <NamesContext.Provider value={{ currentNames, setCurrentNames: vi.fn() }}>
         <Form />
       </NamesContext.Provider>,
     );
-    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-    expect(textarea.value).toBe('John, Jane, Doe');
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("John, Jane, Doe");
   });
 
-  it('clears the textarea when the reset button is clicked', () => {
-    const currentNames = { id: '1', names: ['John', 'Jane', 'Doe'] };
+  it("clears the textarea when the reset button is clicked", () => {
+    const currentNames = { id: "1", names: ["John", "Jane", "Doe"] };
     const setCurrentNames = vi.fn();
     render(
       <NamesContext.Provider value={{ currentNames, setCurrentNames }}>
@@ -30,46 +30,52 @@ describe('Form component', () => {
     );
     const resetButton = screen.getByLabelText(/Clear current list/i);
     fireEvent.click(resetButton);
-    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-    expect(textarea.value).toBe('');
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("");
     expect(setCurrentNames).toHaveBeenCalledWith(null);
   });
 
-  it('calls setCurrentNames with parsed names on submit', () => {
+  it("calls setCurrentNames with parsed names on submit", () => {
     const setCurrentNames = vi.fn();
     render(
       <NamesContext.Provider value={{ currentNames: null, setCurrentNames }}>
         <Form />
       </NamesContext.Provider>,
     );
-    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: 'Alice, Bob, Charlie' } });
-    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Alice, Bob, Charlie" } });
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
     expect(setCurrentNames).toHaveBeenCalledWith({
       id: null,
-      names: parseNames('Alice, Bob, Charlie'),
+      names: parseNames("Alice, Bob, Charlie"),
     });
   });
 
-  it('shows an error when submitted with no names', () => {
+  it("shows an error when submitted with no names", () => {
     render(<Form />);
-    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
-    expect(screen.getByText(/Please enter at least one name/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(
+      screen.getByText(/Please enter at least one name/i),
+    ).toBeInTheDocument();
   });
 
-  it('clears the error when re-submitted with names after an empty submit', () => {
+  it("clears the error when re-submitted with names after an empty submit", () => {
     const setCurrentNames = vi.fn();
     render(
       <NamesContext.Provider value={{ currentNames: null, setCurrentNames }}>
         <Form />
       </NamesContext.Provider>,
     );
-    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
-    expect(screen.getByText(/Please enter at least one name/i)).toBeInTheDocument();
-    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: 'Alice, Bob' } });
-    fireEvent.click(screen.getByRole('button', { name: /generate/i }));
-    expect(screen.queryByText(/Please enter at least one name/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(
+      screen.getByText(/Please enter at least one name/i),
+    ).toBeInTheDocument();
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "Alice, Bob" } });
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    expect(
+      screen.queryByText(/Please enter at least one name/i),
+    ).not.toBeInTheDocument();
     expect(setCurrentNames).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -1,22 +1,28 @@
-import { useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocalStorage } from '@uidotdev/usehooks';
-import { v4 as uuid4 } from 'uuid';
-import _throttle from 'lodash/throttle';
-import { parseNames } from '../utils';
-import { NamesContext } from '../contexts/NamesContext';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { byPrefixAndName } from '@awesome.me/kit-84f13ff524/icons';
-import Textarea from './Fields/Textarea';
-import Switch from './Fields/Switch';
+import { useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useLocalStorage } from "@uidotdev/usehooks";
+import { v4 as uuid4 } from "uuid";
+import _throttle from "lodash/throttle";
+import { parseNames } from "../utils";
+import { NamesContext } from "../contexts/NamesContext";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { byPrefixAndName } from "@awesome.me/kit-84f13ff524/icons";
+import Textarea from "./Fields/Textarea";
+import Switch from "./Fields/Switch";
 
 function Form() {
   const { currentNames, setCurrentNames } = useContext(NamesContext);
-  const [, setStoredNames] = useLocalStorage<Record<string, string[]> | null>('names', null);
+  const [, setStoredNames] = useLocalStorage<Record<string, string[]> | null>(
+    "names",
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
   const [remember, setRemember] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const uniqueId = useMemo(() => currentNames?.id ?? uuid4(), [currentNames?.id]);
+  const uniqueId = useMemo(
+    () => currentNames?.id ?? uuid4(),
+    [currentNames?.id],
+  );
 
   useEffect(() => {
     if (!currentNames) return;
@@ -25,16 +31,19 @@ function Form() {
     const namesArray = currentNames.names;
 
     if (textareaRef.current) {
-      textareaRef.current.value = namesArray.map((v) => (v.includes(' ') ? `"${v}"` : v)).join(', ');
+      textareaRef.current.value = namesArray
+        .map((v) => (v.includes(" ") ? `"${v}"` : v))
+        .join(", ");
     }
   }, [currentNames]);
 
   const handleNamesChange = useMemo(
-    () => _throttle((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      if (error && e.target.value) {
-        setError(null);
-      }
-    }, 300),
+    () =>
+      _throttle((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+        if (error && e.target.value) {
+          setError(null);
+        }
+      }, 300),
     [error],
   );
 
@@ -46,7 +55,7 @@ function Form() {
     setCurrentNames(null);
     setError(null);
     if (textareaRef.current) {
-      textareaRef.current.value = '';
+      textareaRef.current.value = "";
     }
   };
 
@@ -54,20 +63,27 @@ function Form() {
     e.preventDefault();
 
     const form = e.currentTarget;
-    const namesField = form.elements.namedItem('names') as HTMLTextAreaElement;
+    const namesField = form.elements.namedItem("names") as HTMLTextAreaElement;
     if (!namesField.value) {
-      setError('Please enter at least one name.');
+      setError("Please enter at least one name.");
       return;
     }
 
     const namesArray = parseNames(namesField.value);
     let currentId: string | null = null;
 
-    const rememberField = form.elements.namedItem('remember') as HTMLInputElement;
+    const rememberField = form.elements.namedItem(
+      "remember",
+    ) as HTMLInputElement;
     if (rememberField.checked) {
-      const newField = form.elements.namedItem('new') as HTMLInputElement | null;
+      const newField = form.elements.namedItem(
+        "new",
+      ) as HTMLInputElement | null;
       currentId = newField?.checked ? newField.value : rememberField.value;
-      setStoredNames((storedNames) => ({ ...storedNames, [currentId!]: namesArray }));
+      setStoredNames((storedNames) => ({
+        ...storedNames,
+        [currentId!]: namesArray,
+      }));
     }
     setCurrentNames({ id: currentId, names: namesArray });
   };
@@ -75,7 +91,10 @@ function Form() {
   return (
     <form key={uniqueId} name="participants" onSubmit={handleSubmit}>
       <div className="flex justify-between items-center">
-        <label className="block text-slate-600 dark:text-slate-400 mb-1" htmlFor="names">
+        <label
+          className="block text-slate-600 dark:text-slate-400 mb-1"
+          htmlFor="names"
+        >
           Participant names
         </label>
         <button
@@ -85,7 +104,10 @@ function Form() {
           title="Clear current list"
           className="border-0 rounded py-0 px-0.5 text-slate-600 dark:text-slate-400 outline-none outline-offset-0 focus:outline-orange-500/50"
         >
-          <FontAwesomeIcon icon={byPrefixAndName.fal['delete-left']} size="lg" />
+          <FontAwesomeIcon
+            icon={byPrefixAndName.fal["delete-left"]}
+            size="lg"
+          />
         </button>
       </div>
       <div className="mb-1">
@@ -96,13 +118,21 @@ function Form() {
           autoResize
           onChange={handleNamesChange}
         />
-        {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
       </div>
 
       <div className="flex items-center justify-between sm:justify-start gap-x-4">
-        <Switch name="remember" label="Remember this list" checked={!!currentNames?.id} value={uniqueId} onChange={handleRememberChange} />
+        <Switch
+          name="remember"
+          label="Remember this list"
+          checked={!!currentNames?.id}
+          value={uniqueId}
+          onChange={handleRememberChange}
+        />
 
-        {(remember && !!currentNames?.id) && (
+        {remember && !!currentNames?.id && (
           <Switch name="new" label="New list" value={uuid4()} />
         )}
       </div>

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,29 +1,29 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import Header from './Header';
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Header from "./Header";
 
-describe('Header component', () => {
-  it('renders without crashing', () => {
+describe("Header component", () => {
+  it("renders without crashing", () => {
     render(<Header title="Test Title" />);
   });
 
-  it('renders the correct title', () => {
+  it("renders the correct title", () => {
     render(<Header title="Test Title" />);
     const titleElement = screen.getByText(/Test Title/i);
     expect(titleElement).toBeInTheDocument();
   });
 
-  it('renders the correct title case', () => {
+  it("renders the correct title case", () => {
     render(<Header title="test title" />);
     const titleElement = screen.getByText(/Test Title/i);
     expect(titleElement).toBeInTheDocument();
   });
 
-  it('applies the correct CSS classes', () => {
+  it("applies the correct CSS classes", () => {
     render(<Header title="Test Title" />);
     const titleElement = screen.getByText(/Test Title/i);
     expect(titleElement).toHaveClass(
-      'my-8 text-2xl font-thin uppercase tracking-wider text-slate-700 dark:text-slate-300',
+      "my-8 text-2xl font-thin uppercase tracking-wider text-slate-700 dark:text-slate-300",
     );
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import _startCase from 'lodash/startCase';
+import _startCase from "lodash/startCase";
 
 interface IHeaderProps {
   title: string;

--- a/src/components/Results.test.tsx
+++ b/src/components/Results.test.tsx
@@ -1,68 +1,82 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { NamesContext } from '../contexts/NamesContext';
-import Results from './Results';
-import { copyToClipboard } from '../utils';
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NamesContext } from "../contexts/NamesContext";
+import Results from "./Results";
+import { copyToClipboard } from "../utils";
 
-Object.defineProperty(globalThis.navigator, 'clipboard', {
+Object.defineProperty(globalThis.navigator, "clipboard", {
   value: { writeText: vi.fn() },
   configurable: true,
 });
 
-describe('Results component', () => {
-  it('renders without crashing', () => {
+describe("Results component", () => {
+  it("renders without crashing", () => {
     render(
-      <NamesContext.Provider value={{ currentNames: null, setCurrentNames: vi.fn() }}>
+      <NamesContext.Provider
+        value={{ currentNames: null, setCurrentNames: vi.fn() }}
+      >
         <Results />
       </NamesContext.Provider>,
     );
   });
 
-  it('renders the results element', () => {
+  it("renders the results element", () => {
     render(
-      <NamesContext.Provider value={{ currentNames: null, setCurrentNames: vi.fn() }}>
+      <NamesContext.Provider
+        value={{ currentNames: null, setCurrentNames: vi.fn() }}
+      >
         <Results />
       </NamesContext.Provider>,
     );
-    const resultsElement = screen.getByTestId('results');
+    const resultsElement = screen.getByTestId("results");
     expect(resultsElement).toBeInTheDocument();
   });
 
-  it('copies the results to clipboard when copy button is clicked', async () => {
-    const currentNames = { id: '1', names: ['John', 'Jane', 'Doe'] };
+  it("copies the results to clipboard when copy button is clicked", async () => {
+    const currentNames = { id: "1", names: ["John", "Jane", "Doe"] };
     render(
       <NamesContext.Provider value={{ currentNames, setCurrentNames: vi.fn() }}>
         <Results />
       </NamesContext.Provider>,
     );
-    const copyButton = screen.getByRole('button', { name: /copy/i });
+    const copyButton = screen.getByRole("button", { name: /copy/i });
     userEvent.click(copyButton);
 
-    await copyToClipboard('test');
+    await copyToClipboard("test");
     expect(globalThis.navigator.clipboard.writeText).toHaveBeenCalled();
   });
 
-  it('renders the copy icon in the copy button', () => {
+  it("renders the copy icon in the copy button", () => {
     render(
-      <NamesContext.Provider value={{ currentNames: { id: '1', names: ['John', 'Jane'] }, setCurrentNames: vi.fn() }}>
+      <NamesContext.Provider
+        value={{
+          currentNames: { id: "1", names: ["John", "Jane"] },
+          setCurrentNames: vi.fn(),
+        }}
+      >
         <Results />
       </NamesContext.Provider>,
     );
-    const copyIcon = screen.getByTestId('copy-button-icon');
+    const copyIcon = screen.getByTestId("copy-button-icon");
     expect(copyIcon).toBeInTheDocument();
-    expect(copyIcon).toHaveAttribute('data-icon', 'copy');
+    expect(copyIcon).toHaveAttribute("data-icon", "copy");
   });
 
-  it('renders the results from context', () => {
+  it("renders the results from context", () => {
     render(
-      <NamesContext.Provider value={{ currentNames: { id: '1', names: ['John', 'Jane'] }, setCurrentNames: vi.fn() }}>
+      <NamesContext.Provider
+        value={{
+          currentNames: { id: "1", names: ["John", "Jane"] },
+          setCurrentNames: vi.fn(),
+        }}
+      >
         <Results />
       </NamesContext.Provider>,
     );
-    const resultsElement = screen.getByTestId('results');
-    expect(resultsElement.textContent).toContain('John');
-    expect(resultsElement.textContent).toContain('Jane');
-    expect(resultsElement.textContent).not.toContain('Doe');
+    const resultsElement = screen.getByTestId("results");
+    expect(resultsElement.textContent).toContain("John");
+    expect(resultsElement.textContent).toContain("Jane");
+    expect(resultsElement.textContent).not.toContain("Doe");
   });
 });

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,20 +1,25 @@
-import { useContext } from 'react';
-import { useLocalStorage } from '@uidotdev/usehooks';
-import { generate } from '../utils';
-import { DEFAULT_OPTIONS } from '../utils/constants';
-import type { IOptions } from '../utils/constants';
-import { NamesContext } from '../contexts/NamesContext';
-import CopyButton from './CopyButton';
+import { useContext } from "react";
+import { useLocalStorage } from "@uidotdev/usehooks";
+import { generate } from "../utils";
+import { DEFAULT_OPTIONS } from "../utils/constants";
+import type { IOptions } from "../utils/constants";
+import { NamesContext } from "../contexts/NamesContext";
+import CopyButton from "./CopyButton";
 
 function Results() {
   const { currentNames } = useContext(NamesContext);
-  const [storedOptions] = useLocalStorage<Partial<IOptions> | null>('options', null);
-  const localOptions = storedOptions ? { ...DEFAULT_OPTIONS, ...storedOptions } : DEFAULT_OPTIONS;
+  const [storedOptions] = useLocalStorage<Partial<IOptions> | null>(
+    "options",
+    null,
+  );
+  const localOptions = storedOptions
+    ? { ...DEFAULT_OPTIONS, ...storedOptions }
+    : DEFAULT_OPTIONS;
 
   const results = generate(currentNames?.names, localOptions);
   return (
     <div
-      className={`group relative mx-auto my-8 py-3 px-5 text-2xl text-slate-700 dark:text-slate-300 border rounded border-slate-300 dark:border-slate-700 focus:border-slate-400 dark:focus:border-slate-600 outline-none ${results ?? 'hidden'}`}
+      className={`group relative mx-auto my-8 py-3 px-5 text-2xl text-slate-700 dark:text-slate-300 border rounded border-slate-300 dark:border-slate-700 focus:border-slate-400 dark:focus:border-slate-600 outline-none ${results ?? "hidden"}`}
       tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
     >
       <CopyButton text={results} />

--- a/src/components/StoredNames/ConfirmDialog.test.tsx
+++ b/src/components/StoredNames/ConfirmDialog.test.tsx
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import ConfirmDialog from './ConfirmDialog';
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ConfirmDialog from "./ConfirmDialog";
 
 // Mock ResizeObserver
 class ResizeObserver {
@@ -9,56 +9,58 @@ class ResizeObserver {
   unobserve = vi.fn();
 }
 
-Object.defineProperty(window, 'ResizeObserver', {
+Object.defineProperty(window, "ResizeObserver", {
   writable: true,
   configurable: true,
   value: ResizeObserver,
 });
 
-describe('ConfirmDialog component', () => {
-  it('renders without crashing', () => {
+describe("ConfirmDialog component", () => {
+  it("renders without crashing", () => {
     render(<ConfirmDialog />);
   });
 
-  it('nothing displays when not `open`', async () => {
-    const additionalText = 'John, Jane Doe';
+  it("nothing displays when not `open`", async () => {
+    const additionalText = "John, Jane Doe";
     render(<ConfirmDialog additionalText={additionalText} />);
 
-    expect(screen.queryByTestId('confirm-dialog-title')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("confirm-dialog-title"),
+    ).not.toBeInTheDocument();
   });
 
-  it('displays the additional text', async () => {
-    const additionalText = 'John, Jane Doe';
+  it("displays the additional text", async () => {
+    const additionalText = "John, Jane Doe";
     render(<ConfirmDialog open additionalText={additionalText} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('confirm-dialog-title')).toBeInTheDocument();
+      expect(screen.getByTestId("confirm-dialog-title")).toBeInTheDocument();
       expect(screen.getByText(/John, Jane Doe/i)).toBeInTheDocument();
     });
   });
 
-  it('calls the confirmAction function when the confirm button is clicked', async () => {
+  it("calls the confirmAction function when the confirm button is clicked", async () => {
     const confirmAction = vi.fn();
     render(<ConfirmDialog open confirmAction={confirmAction} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('confirm-dialog-title')).toBeInTheDocument();
+      expect(screen.getByTestId("confirm-dialog-title")).toBeInTheDocument();
     });
 
-    const confirmButton = screen.getByRole('button', { name: /delete/i });
+    const confirmButton = screen.getByRole("button", { name: /delete/i });
     fireEvent.click(confirmButton);
     expect(confirmAction).toHaveBeenCalled();
   });
 
-  it('calls the closeAction function when the close button is clicked', async () => {
+  it("calls the closeAction function when the close button is clicked", async () => {
     const closeAction = vi.fn();
     render(<ConfirmDialog open closeAction={closeAction} />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('confirm-dialog-title')).toBeInTheDocument();
+      expect(screen.getByTestId("confirm-dialog-title")).toBeInTheDocument();
     });
 
-    const closeButton = screen.getByRole('button', { name: /cancel/i });
+    const closeButton = screen.getByRole("button", { name: /cancel/i });
     fireEvent.click(closeButton);
     expect(closeAction).toHaveBeenCalled();
   });

--- a/src/components/StoredNames/ConfirmDialog.tsx
+++ b/src/components/StoredNames/ConfirmDialog.tsx
@@ -1,7 +1,13 @@
-import { useRef } from 'react';
-import { Dialog, DialogPanel, DialogTitle, Transition, TransitionChild } from '@headlessui/react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { byPrefixAndName } from '@awesome.me/kit-84f13ff524/icons';
+import { useRef } from "react";
+import {
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+  Transition,
+  TransitionChild,
+} from "@headlessui/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { byPrefixAndName } from "@awesome.me/kit-84f13ff524/icons";
 
 interface IConfirmDialogProps {
   additionalText?: string | null;
@@ -10,12 +16,22 @@ interface IConfirmDialogProps {
   confirmAction?: () => void;
 }
 
-export default function ConfirmDialog({ additionalText = null, open = false, closeAction = () => {}, confirmAction = () => {} }: IConfirmDialogProps) {
+export default function ConfirmDialog({
+  additionalText = null,
+  open = false,
+  closeAction = () => {},
+  confirmAction = () => {},
+}: IConfirmDialogProps) {
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
 
   return (
     <Transition show={open}>
-      <Dialog as="div" className="relative z-10" initialFocus={cancelButtonRef} onClose={closeAction}>
+      <Dialog
+        as="div"
+        className="relative z-10"
+        initialFocus={cancelButtonRef}
+        onClose={closeAction}
+      >
         <TransitionChild
           enter="ease-out duration-300"
           enterFrom="opacity-0"
@@ -42,7 +58,7 @@ export default function ConfirmDialog({ additionalText = null, open = false, clo
                   <div className="sm:flex sm:items-start">
                     <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 dark:bg-red-200 sm:mx-0 sm:h-10 sm:w-10">
                       <FontAwesomeIcon
-                        icon={byPrefixAndName.fal['triangle-exclamation']}
+                        icon={byPrefixAndName.fal["triangle-exclamation"]}
                         className="h-6 w-6 text-red-600 dark:text-red-700"
                         aria-hidden="true"
                       />
@@ -65,7 +81,8 @@ export default function ConfirmDialog({ additionalText = null, open = false, clo
                           </p>
                         )}
                         <p className="text-sm text-slate-500 dark:text-slate-200">
-                          The data will be permanently removed. This action cannot be undone.
+                          The data will be permanently removed. This action
+                          cannot be undone.
                         </p>
                       </div>
                     </div>

--- a/src/components/StoredNames/ListItem.test.tsx
+++ b/src/components/StoredNames/ListItem.test.tsx
@@ -1,12 +1,15 @@
-import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import ListItem from './ListItem';
-import { NamesContext } from '../../contexts/NamesContext';
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ListItem from "./ListItem";
+import { NamesContext } from "../../contexts/NamesContext";
 
-describe('ListItem component', () => {
-  const contextValue = { currentNames: { id: '1', names: ['John', 'Jane'] }, setCurrentNames: vi.fn() };
+describe("ListItem component", () => {
+  const contextValue = {
+    currentNames: { id: "1", names: ["John", "Jane"] },
+    setCurrentNames: vi.fn(),
+  };
 
-  it('renders without crashing', () => {
+  it("renders without crashing", () => {
     render(
       <NamesContext.Provider value={contextValue}>
         <ListItem id="1" names={[]} onSelect={() => {}} onDelete={() => {}} />
@@ -14,8 +17,8 @@ describe('ListItem component', () => {
     );
   });
 
-  it('displays the names correctly', () => {
-    const names = ['John', 'Jane Doe'];
+  it("displays the names correctly", () => {
+    const names = ["John", "Jane Doe"];
     render(
       <NamesContext.Provider value={contextValue}>
         <ListItem id="2" names={names} onSelect={() => {}} onDelete={vi.fn()} />

--- a/src/components/StoredNames/ListItem.tsx
+++ b/src/components/StoredNames/ListItem.tsx
@@ -1,8 +1,8 @@
-import { useContext, useState } from 'react';
-import { NamesContext } from '../../contexts/NamesContext';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { byPrefixAndName } from '@awesome.me/kit-84f13ff524/icons';
-import ConfirmDialog from './ConfirmDialog';
+import { useContext, useState } from "react";
+import { NamesContext } from "../../contexts/NamesContext";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { byPrefixAndName } from "@awesome.me/kit-84f13ff524/icons";
+import ConfirmDialog from "./ConfirmDialog";
 
 interface IListItemProps {
   id: string;
@@ -14,7 +14,9 @@ interface IListItemProps {
 function ListItem({ id, names, onSelect, onDelete }: IListItemProps) {
   const { currentNames, setCurrentNames } = useContext(NamesContext);
   const [showConfirm, setShowConfirm] = useState(false);
-  const displayNames = names?.map((v) => (v.includes(' ') ? `"${v}"` : v)).join(', ');
+  const displayNames = names
+    ?.map((v) => (v.includes(" ") ? `"${v}"` : v))
+    .join(", ");
 
   const handleClick = () => {
     if (currentNames?.id !== id) {
@@ -34,7 +36,10 @@ function ListItem({ id, names, onSelect, onDelete }: IListItemProps) {
   return (
     <>
       <li className="border-b border-slate-400 flex items-center text-slate-600 dark:text-slate-400">
-        <button className="py-4 ps-4 flex-auto text-start" onClick={handleClick}>
+        <button
+          className="py-4 ps-4 flex-auto text-start"
+          onClick={handleClick}
+        >
           {displayNames}
         </button>
         <button
@@ -43,7 +48,7 @@ function ListItem({ id, names, onSelect, onDelete }: IListItemProps) {
           aria-label="Delete"
           title="Delete"
         >
-          <FontAwesomeIcon icon={byPrefixAndName.fal['trash-alt']} />
+          <FontAwesomeIcon icon={byPrefixAndName.fal["trash-alt"]} />
         </button>
       </li>
 

--- a/src/components/StoredNames/StoredNames.test.tsx
+++ b/src/components/StoredNames/StoredNames.test.tsx
@@ -1,13 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import StoredNames from './StoredNames';
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import StoredNames from "./StoredNames";
 
-describe('StoredNames component', () => {
-  it('renders without crashing', () => {
+describe("StoredNames component", () => {
+  it("renders without crashing", () => {
     render(<StoredNames />);
   });
 
-  it('displays a message when there are no stored names', () => {
+  it("displays a message when there are no stored names", () => {
     render(<StoredNames />);
     const message = screen.getByText(/No stored lists/i);
     expect(message).toBeInTheDocument();

--- a/src/components/StoredNames/StoredNames.tsx
+++ b/src/components/StoredNames/StoredNames.tsx
@@ -1,15 +1,18 @@
-import { useCallback } from 'react';
-import { useLocalStorage } from '@uidotdev/usehooks';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { byPrefixAndName } from '@awesome.me/kit-84f13ff524/icons';
-import ListItem from './ListItem';
+import { useCallback } from "react";
+import { useLocalStorage } from "@uidotdev/usehooks";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { byPrefixAndName } from "@awesome.me/kit-84f13ff524/icons";
+import ListItem from "./ListItem";
 
 interface IStoredNamesProps {
   onSelect?: () => void;
 }
 
 function StoredNames({ onSelect = () => {} }: IStoredNamesProps) {
-  const [storedNames, setStoredNames] = useLocalStorage<Record<string, string[]> | null>('names', null);
+  const [storedNames, setStoredNames] = useLocalStorage<Record<
+    string,
+    string[]
+  > | null>("names", null);
 
   const handleDelete = useCallback(
     (id: string) => {
@@ -26,14 +29,23 @@ function StoredNames({ onSelect = () => {} }: IStoredNamesProps) {
     <>
       {(!storedNames || Object.keys(storedNames).length === 0) && (
         <p className="p-4 text-slate-600 dark:text-slate-400">
-          <FontAwesomeIcon icon={byPrefixAndName.fal['exclamation-triangle']} className="text-orange-500 me-2" />
+          <FontAwesomeIcon
+            icon={byPrefixAndName.fal["exclamation-triangle"]}
+            className="text-orange-500 me-2"
+          />
           No stored lists
         </p>
       )}
       <ul className="list-none">
         {storedNames &&
           Object.entries(storedNames).map(([k, v]) => (
-            <ListItem key={k} id={k} names={v} onDelete={handleDelete} onSelect={onSelect} />
+            <ListItem
+              key={k}
+              id={k}
+              names={v}
+              onDelete={handleDelete}
+              onSelect={onSelect}
+            />
           ))}
       </ul>
     </>

--- a/src/contexts/NamesContext.ts
+++ b/src/contexts/NamesContext.ts
@@ -1,5 +1,5 @@
-import { createContext } from 'react';
-import type { Dispatch, SetStateAction } from 'react';
+import { createContext } from "react";
+import type { Dispatch, SetStateAction } from "react";
 
 export interface INamesEntry {
   id: string | null;

--- a/src/contexts/NamesProvider.test.tsx
+++ b/src/contexts/NamesProvider.test.tsx
@@ -1,57 +1,63 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { useContext } from 'react';
-import NamesProvider from './NamesProvider';
-import { NamesContext } from './NamesContext';
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useContext } from "react";
+import NamesProvider from "./NamesProvider";
+import { NamesContext } from "./NamesContext";
 
 function TestConsumer() {
   const { currentNames, setCurrentNames } = useContext(NamesContext);
   return (
     <div>
-      <span data-testid="names">{currentNames ? currentNames.names.join(', ') : 'none'}</span>
-      <button onClick={() => setCurrentNames({ id: '1', names: ['Alice', 'Bob'] })}>set</button>
+      <span data-testid="names">
+        {currentNames ? currentNames.names.join(", ") : "none"}
+      </span>
+      <button
+        onClick={() => setCurrentNames({ id: "1", names: ["Alice", "Bob"] })}
+      >
+        set
+      </button>
       <button onClick={() => setCurrentNames(null)}>clear</button>
     </div>
   );
 }
 
-describe('NamesProvider', () => {
-  it('renders children', () => {
+describe("NamesProvider", () => {
+  it("renders children", () => {
     render(
       <NamesProvider>
         <span>child</span>
       </NamesProvider>,
     );
-    expect(screen.getByText('child')).toBeInTheDocument();
+    expect(screen.getByText("child")).toBeInTheDocument();
   });
 
-  it('provides null currentNames by default', () => {
+  it("provides null currentNames by default", () => {
     render(
       <NamesProvider>
         <TestConsumer />
       </NamesProvider>,
     );
-    expect(screen.getByTestId('names').textContent).toBe('none');
+    expect(screen.getByTestId("names").textContent).toBe("none");
   });
 
-  it('allows updating currentNames via setCurrentNames', () => {
+  it("allows updating currentNames via setCurrentNames", () => {
     render(
       <NamesProvider>
         <TestConsumer />
       </NamesProvider>,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'set' }));
-    expect(screen.getByTestId('names').textContent).toBe('Alice, Bob');
+    fireEvent.click(screen.getByRole("button", { name: "set" }));
+    expect(screen.getByTestId("names").textContent).toBe("Alice, Bob");
   });
 
-  it('allows clearing currentNames', () => {
+  it("allows clearing currentNames", () => {
     render(
       <NamesProvider>
         <TestConsumer />
       </NamesProvider>,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'set' }));
-    fireEvent.click(screen.getByRole('button', { name: 'clear' }));
-    expect(screen.getByTestId('names').textContent).toBe('none');
+    fireEvent.click(screen.getByRole("button", { name: "set" }));
+    fireEvent.click(screen.getByRole("button", { name: "clear" }));
+    expect(screen.getByTestId("names").textContent).toBe("none");
   });
 });

--- a/src/contexts/NamesProvider.tsx
+++ b/src/contexts/NamesProvider.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react';
-import type { ReactNode } from 'react';
-import { NamesContext } from './NamesContext';
-import type { INamesEntry } from './NamesContext';
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { NamesContext } from "./NamesContext";
+import type { INamesEntry } from "./NamesContext";
 
 const NamesProvider = ({ children }: { children: ReactNode }) => {
   const [currentNames, setCurrentNames] = useState<INamesEntry | null>(null);
 
-  return <NamesContext.Provider value={{ currentNames, setCurrentNames }}>{children}</NamesContext.Provider>;
+  return (
+    <NamesContext.Provider value={{ currentNames, setCurrentNames }}>
+      {children}
+    </NamesContext.Provider>
+  );
 };
 
 export default NamesProvider;

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,9 +1,9 @@
-import { describe, it } from 'vitest';
-import { render } from '@testing-library/react';
-import App from './App';
+import { describe, it } from "vitest";
+import { render } from "@testing-library/react";
+import App from "./App";
 
-describe('App component', () => {
-  it('renders without crashing', () => {
+describe("App component", () => {
+  it("renders without crashing", () => {
     render(<App />);
   });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
-import { StrictMode } from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import './css/index.css';
+import { StrictMode } from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./css/index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/src/types/awesome-me.d.ts
+++ b/src/types/awesome-me.d.ts
@@ -1,4 +1,4 @@
-declare module '@awesome.me/kit-84f13ff524/icons' {
-  import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+declare module "@awesome.me/kit-84f13ff524/icons" {
+  import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
   export const byPrefixAndName: Record<string, Record<string, IconDefinition>>;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_OPTIONS = {
-  prefix: 'Speaking order:',
-  separator: ',',
-  lastSeparator: 'then',
+  prefix: "Speaking order:",
+  separator: ",",
+  lastSeparator: "then",
   oxfordComma: false,
 };
 

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -1,123 +1,146 @@
-import { describe, expect, it, vi } from 'vitest';
-import { copyToClipboard, generate, joinAnd, parseNames, sentenceCase, shuffle } from '.';
+import { describe, expect, it, vi } from "vitest";
+import {
+  copyToClipboard,
+  generate,
+  joinAnd,
+  parseNames,
+  sentenceCase,
+  shuffle,
+} from ".";
 
-describe('sentenceCase function', () => {
-  it('converts a string to sentence case', () => {
-    const input = 'hello world';
+describe("sentenceCase function", () => {
+  it("converts a string to sentence case", () => {
+    const input = "hello world";
     const output = sentenceCase(input);
-    expect(output).toEqual('Hello world');
+    expect(output).toEqual("Hello world");
   });
 
-  it('leaves a string that is already in sentence case unchanged', () => {
-    const input = 'Hello world';
+  it("leaves a string that is already in sentence case unchanged", () => {
+    const input = "Hello world";
     const output = sentenceCase(input);
-    expect(output).toEqual('Hello world');
+    expect(output).toEqual("Hello world");
   });
 
-  it('converts a string with multiple words to sentence case', () => {
-    const input = 'HELLO WORLD';
+  it("converts a string with multiple words to sentence case", () => {
+    const input = "HELLO WORLD";
     const output = sentenceCase(input);
-    expect(output).toEqual('Hello world');
+    expect(output).toEqual("Hello world");
   });
 
-  it('converts a string with special characters to sentence case', () => {
-    const input = 'hello-world';
+  it("converts a string with special characters to sentence case", () => {
+    const input = "hello-world";
     const output = sentenceCase(input);
-    expect(output).toEqual('Hello world');
+    expect(output).toEqual("Hello world");
   });
 });
 
-describe('parseNames function', () => {
-  it('parses a string of names into an array', () => {
-    const names = 'John, Jane, Doe';
+describe("parseNames function", () => {
+  it("parses a string of names into an array", () => {
+    const names = "John, Jane, Doe";
     const result = parseNames(names);
-    expect(result).toEqual(['John', 'Jane', 'Doe']);
+    expect(result).toEqual(["John", "Jane", "Doe"]);
   });
 
-  it('removes extra spaces from names', () => {
-    const names = 'John , Jane  , Doe ';
+  it("removes extra spaces from names", () => {
+    const names = "John , Jane  , Doe ";
     const result = parseNames(names);
-    expect(result).toEqual(['John', 'Jane', 'Doe']);
+    expect(result).toEqual(["John", "Jane", "Doe"]);
   });
 
-  it('parses space-delimited names', () => {
-    const names = 'John Jane Doe';
+  it("parses space-delimited names", () => {
+    const names = "John Jane Doe";
     const result = parseNames(names);
-    expect(result).toEqual(['John', 'Jane', 'Doe']);
+    expect(result).toEqual(["John", "Jane", "Doe"]);
   });
 
-  it('removes quotes from names', () => {
+  it("removes quotes from names", () => {
     const names = '"John", "Jane", "Doe"';
     const result = parseNames(names);
-    expect(result).toEqual(['John', 'Jane', 'Doe']);
+    expect(result).toEqual(["John", "Jane", "Doe"]);
   });
 
-  it('maintains quoted names with spaces', () => {
+  it("maintains quoted names with spaces", () => {
     const names = '"John", "Jane", "Doe", "John Doe"';
     const result = parseNames(names);
-    expect(result).toEqual(['John', 'Jane', 'Doe', 'John Doe']);
+    expect(result).toEqual(["John", "Jane", "Doe", "John Doe"]);
   });
 
-  it('returns an empty array if the input is an empty string', () => {
-    const names = '';
+  it("returns an empty array if the input is an empty string", () => {
+    const names = "";
     const result = parseNames(names);
     expect(result).toEqual([]);
   });
 });
 
-describe('shuffle function', () => {
-  it('returns an array with the same length after shuffling', () => {
-    const array = ['John', 'Jane', 'Doe'];
+describe("shuffle function", () => {
+  it("returns an array with the same length after shuffling", () => {
+    const array = ["John", "Jane", "Doe"];
     const result = shuffle(array);
     expect(result.length).toBe(array.length);
   });
 
-  it('returns an array with the same elements after shuffling', () => {
-    const array = ['John', 'Jane', 'Doe'];
+  it("returns an array with the same elements after shuffling", () => {
+    const array = ["John", "Jane", "Doe"];
     const result = shuffle(array);
     const sortedOriginal = [...array].sort();
     const sortedResult = [...result].sort();
     expect(sortedResult).toEqual(sortedOriginal);
   });
 
-  it('returns an empty array if the input array is empty', () => {
+  it("returns an empty array if the input array is empty", () => {
     const array: string[] = [];
     const result = shuffle(array);
     expect(result).toEqual([]);
   });
 });
 
-describe('joinAnd function', () => {
-  it('returns an empty string for an empty array', () => {
-    expect(joinAnd([])).toBe('');
+describe("joinAnd function", () => {
+  it("returns an empty string for an empty array", () => {
+    expect(joinAnd([])).toBe("");
   });
 
-  it('returns the only element for an array with one element', () => {
-    expect(joinAnd(['apple'])).toBe('apple');
+  it("returns the only element for an array with one element", () => {
+    expect(joinAnd(["apple"])).toBe("apple");
   });
 
-  it('joins two elements with the default separator and last separator', () => {
-    expect(joinAnd(['apple', 'banana'])).toBe('apple and banana');
+  it("joins two elements with the default separator and last separator", () => {
+    expect(joinAnd(["apple", "banana"])).toBe("apple and banana");
   });
 
-  it('joins two elements with a custom separator and last separator', () => {
-    expect(joinAnd(['apple', 'banana'], { separator: ';', lastSeparator: '&' })).toBe('apple & banana');
+  it("joins two elements with a custom separator and last separator", () => {
+    expect(
+      joinAnd(["apple", "banana"], { separator: ";", lastSeparator: "&" }),
+    ).toBe("apple & banana");
   });
 
-  it('joins multiple elements with the default separator and last separator', () => {
-    expect(joinAnd(['apple', 'banana', 'cherry'])).toBe('apple, banana and cherry');
+  it("joins multiple elements with the default separator and last separator", () => {
+    expect(joinAnd(["apple", "banana", "cherry"])).toBe(
+      "apple, banana and cherry",
+    );
   });
 
-  it('joins multiple elements with a custom separator and last separator', () => {
-    expect(joinAnd(['apple', 'banana', 'cherry'], { separator: ';', lastSeparator: '&' })).toBe('apple; banana & cherry');
+  it("joins multiple elements with a custom separator and last separator", () => {
+    expect(
+      joinAnd(["apple", "banana", "cherry"], {
+        separator: ";",
+        lastSeparator: "&",
+      }),
+    ).toBe("apple; banana & cherry");
   });
 
-  it('joins multiple elements with an oxford comma', () => {
-    expect(joinAnd(['apple', 'banana', 'cherry'], { oxfordComma: true })).toBe('apple, banana, and cherry');
+  it("joins multiple elements with an oxford comma", () => {
+    expect(joinAnd(["apple", "banana", "cherry"], { oxfordComma: true })).toBe(
+      "apple, banana, and cherry",
+    );
   });
 
-  it('joins elements when the separator and last separator are the same', () => {
-    expect(joinAnd(['apple', 'banana', 'cherry'], { separator: 'and', lastSeparator: 'and' })).toBe('appleand bananaand cherry');
+  it("joins elements when the separator and last separator are the same", () => {
+    expect(
+      joinAnd(["apple", "banana", "cherry"], {
+        separator: "and",
+        lastSeparator: "and",
+      }),
+    ).toBe("appleand bananaand cherry");
   });
 });
 
@@ -126,63 +149,67 @@ describe('joinAnd function', () => {
 //   shuffle: vi.fn(),
 // }));
 
-describe('generate function', () => {
-  it('returns null if names is not an array', () => {
-    expect(generate('not an array')).toBeNull();
+describe("generate function", () => {
+  it("returns null if names is not an array", () => {
+    expect(generate("not an array")).toBeNull();
   });
 
-  it('returns null for a non-array value', () => {
+  it("returns null for a non-array value", () => {
     expect(generate(42)).toBeNull();
   });
 
-  it('returns a string for an empty array', () => {
+  it("returns a string for an empty array", () => {
     const result = generate([]);
-    expect(typeof result).toBe('string');
+    expect(typeof result).toBe("string");
   });
 
-  it('includes the prefix in the result', () => {
-    const result = generate(['Alice'], { prefix: 'Order:' });
+  it("includes the prefix in the result", () => {
+    const result = generate(["Alice"], { prefix: "Order:" });
     expect(result).toMatch(/^Order:/);
   });
 
-  it('includes all names in the result', () => {
-    const names = ['Alice', 'Bob', 'Carol'];
+  it("includes all names in the result", () => {
+    const names = ["Alice", "Bob", "Carol"];
     const result = generate(names);
-    expect(result).toContain('Alice');
-    expect(result).toContain('Bob');
-    expect(result).toContain('Carol');
+    expect(result).toContain("Alice");
+    expect(result).toContain("Bob");
+    expect(result).toContain("Carol");
   });
 
-  it('uses a custom prefix', () => {
-    const result = generate(['Alice'], { prefix: 'Speaking order:' });
+  it("uses a custom prefix", () => {
+    const result = generate(["Alice"], { prefix: "Speaking order:" });
     expect(result).toMatch(/^Speaking order:/);
   });
 
-  it('uses a custom lastSeparator', () => {
-    const result = generate(['Alice', 'Bob'], { lastSeparator: 'then' });
-    expect(result).toContain('then');
+  it("uses a custom lastSeparator", () => {
+    const result = generate(["Alice", "Bob"], { lastSeparator: "then" });
+    expect(result).toContain("then");
   });
 
-  it('uses the oxford comma option', () => {
-    const result = generate(['Alice', 'Bob', 'Carol'], { separator: ',', lastSeparator: 'and', oxfordComma: true });
+  it("uses the oxford comma option", () => {
+    const result = generate(["Alice", "Bob", "Carol"], {
+      separator: ",",
+      lastSeparator: "and",
+      oxfordComma: true,
+    });
     expect(result).toMatch(/,\s+and\s+/);
   });
 
-  it('returns a different order on repeated calls (shuffle)', () => {
-    const names = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve'];
+  it("returns a different order on repeated calls (shuffle)", () => {
+    const names = ["Alice", "Bob", "Carol", "Dave", "Eve"];
     const results = new Set(Array.from({ length: 20 }, () => generate(names)));
     expect(results.size).toBeGreaterThan(1);
   });
 });
 
-Object.defineProperty(globalThis.navigator, 'clipboard', {
+Object.defineProperty(globalThis.navigator, "clipboard", {
   value: { writeText: vi.fn() },
   configurable: true,
 });
 
-describe('copyToClipboard function', () => {
-  it('copies text to clipboard', async () => {
-    const text = 'Hello, World!';
+describe("copyToClipboard function", () => {
+  it("copies text to clipboard", async () => {
+    const text = "Hello, World!";
     await copyToClipboard(text);
     expect(globalThis.navigator.clipboard.writeText).toHaveBeenCalledWith(text);
   });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
-import _capitalize from 'lodash/capitalize';
-import _lowerCase from 'lodash/lowerCase';
-import { DEFAULT_OPTIONS } from './constants';
-import type { IOptions } from './constants';
+import _capitalize from "lodash/capitalize";
+import _lowerCase from "lodash/lowerCase";
+import { DEFAULT_OPTIONS } from "./constants";
+import type { IOptions } from "./constants";
 
 interface IJoinOptions {
   separator?: string;
@@ -16,13 +16,13 @@ export function sentenceCase(text: string): string {
 export function parseNames(text: string | null | undefined): string[] {
   if (!text) return [];
   return (text.match(/(".*?"|[^"\s,;]+)+(?=\s*|\s*$)/gm) ?? [])
-    .map((n) => n.replace(/"/g, '').trim())
+    .map((n) => n.replace(/"/g, "").trim())
     .filter((n) => n.length > 0);
 }
 
 export function shuffle<T>(array: T[]): T[] {
   if (!Array.isArray(array)) {
-    throw new Error('shuffle() expects an array');
+    throw new Error("shuffle() expects an array");
   }
 
   const returnArray = [...array];
@@ -40,9 +40,16 @@ export function shuffle<T>(array: T[]): T[] {
   return returnArray;
 }
 
-export function joinAnd(array: string[], { separator = ',', lastSeparator = 'and', oxfordComma = false }: IJoinOptions = {}): string {
+export function joinAnd(
+  array: string[],
+  {
+    separator = ",",
+    lastSeparator = "and",
+    oxfordComma = false,
+  }: IJoinOptions = {},
+): string {
   if (!Array.isArray(array) || array.length === 0) {
-    return '';
+    return "";
   }
   if (array.length === 1) {
     return array[0].toString();
@@ -51,17 +58,23 @@ export function joinAnd(array: string[], { separator = ',', lastSeparator = 'and
     return array.join(`${separator} `);
   }
   if (array.length === 2) {
-    return `${array[0]}${separator !== lastSeparator ? ' ' : ''}${lastSeparator} ${array[1]}`;
+    return `${array[0]}${separator !== lastSeparator ? " " : ""}${lastSeparator} ${array[1]}`;
   }
   const returnArray = [...array];
   const last = returnArray.pop()!;
-  return `${returnArray.join(`${separator} `)}${oxfordComma ? separator : ''} ${lastSeparator} ${last}`;
+  return `${returnArray.join(`${separator} `)}${oxfordComma ? separator : ""} ${lastSeparator} ${last}`;
 }
 
-export function generate(names: unknown, options: Partial<IOptions> = {}): string | null {
+export function generate(
+  names: unknown,
+  options: Partial<IOptions> = {},
+): string | null {
   if (!Array.isArray(names)) return null;
 
-  const { prefix, separator, lastSeparator, oxfordComma } = { ...DEFAULT_OPTIONS, ...options };
+  const { prefix, separator, lastSeparator, oxfordComma } = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
   const shuffledNames = shuffle(names as string[]);
   return `${prefix} ${joinAnd(shuffledNames, { separator, lastSeparator, oxfordComma })}`;
 }
@@ -71,7 +84,7 @@ export function copyToClipboard(text: string): void {
     try {
       await navigator.clipboard.writeText(text);
     } catch (err) {
-      console.error('Failed to copy: ', err);
+      console.error("Failed to copy: ", err);
     }
   };
   copyContent();

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,7 +1,7 @@
-import '@testing-library/jest-dom';
-import { vi } from 'vitest';
+import "@testing-library/jest-dom";
+import { vi } from "vitest";
 
-Object.defineProperty(window, 'matchMedia', {
+Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: vi.fn().mockImplementation((query) => ({
     matches: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,22 +1,19 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  base: './',
+  base: "./",
   build: {
     rollupOptions: {
       output: [
-        { dir: 'dist' },
-        { dir: 'dist/order' }, // For Netlify subdirectory
+        { dir: "dist" },
+        { dir: "dist/order" }, // For Netlify subdirectory
       ],
     },
   },
   server: {
     port: 3090,
   },
-  plugins: [
-    react(),
-    tailwindcss(),
-  ],
+  plugins: [react(), tailwindcss()],
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,23 +1,23 @@
-import { mergeConfig } from 'vite';
-import { defineConfig } from 'vitest/config';
-import viteConfig from './vite.config';
+import { mergeConfig } from "vite";
+import { defineConfig } from "vitest/config";
+import viteConfig from "./vite.config";
 
 export default mergeConfig(
   viteConfig,
   defineConfig({
     test: {
-      environment: 'jsdom',
+      environment: "jsdom",
       globals: true,
-      setupFiles: './tests/setup.ts',
+      setupFiles: "./tests/setup.ts",
       coverage: {
-        reporter: ['text', 'json', 'html'],
+        reporter: ["text", "json", "html"],
         exclude: [
-          'node_modules/**',
-          'coverage/**',
-          'dist/**',
-          '**/{vite,vitest,tailwind}.config.{js,ts}',
+          "node_modules/**",
+          "coverage/**",
+          "dist/**",
+          "**/{vite,vitest,tailwind}.config.{js,ts}",
         ],
-        include: ['src/**/*.{ts,tsx}'],
+        include: ["src/**/*.{ts,tsx}"],
       },
     },
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,18 +826,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stylistic/eslint-plugin-js@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "@stylistic/eslint-plugin-js@npm:4.2.0"
-  dependencies:
-    eslint-visitor-keys: "npm:^4.2.0"
-    espree: "npm:^10.3.0"
-  peerDependencies:
-    eslint: ">=9.0.0"
-  checksum: 10c0/5e5a21a60c818fc9f745b12fab252a1188e4d98d7008a81dbaf5a8e106558ac757c4c56e2a4b982bd97249132a31f577a991383f77b4912b8b26723d57654256
-  languageName: node
-  linkType: hard
-
 "@swc/helpers@npm:^0.5.0":
   version: 0.5.17
   resolution: "@swc/helpers@npm:0.5.17"
@@ -2267,6 +2255,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-config-prettier@npm:^10.1.8":
+  version: 10.1.8
+  resolution: "eslint-config-prettier@npm:10.1.8"
+  peerDependencies:
+    eslint: ">=7.0.0"
+  bin:
+    eslint-config-prettier: bin/cli.js
+  checksum: 10c0/e1bcfadc9eccd526c240056b1e59c5cd26544fe59feb85f38f4f1f116caed96aea0b3b87868e68b3099e55caaac3f2e5b9f58110f85db893e83a332751192682
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-jsx-a11y@npm:^6.10.2":
   version: 6.10.2
   resolution: "eslint-plugin-jsx-a11y@npm:6.10.2"
@@ -2831,6 +2830,15 @@ __metadata:
     agent-base: "npm:^7.1.2"
     debug: "npm:4"
   checksum: 10c0/f729219bc735edb621fa30e6e84e60ee5d00802b8247aac0d7b79b0bd6d4b3294737a337b93b86a0bd9e68099d031858a39260c976dc14cdbba238ba1f8779ac
+  languageName: node
+  linkType: hard
+
+"husky@npm:^9.1.7":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
+  bin:
+    husky: bin.js
+  checksum: 10c0/35bb110a71086c48906aa7cd3ed4913fb913823715359d65e32e0b964cb1e255593b0ae8014a5005c66a68e6fa66c38dcfa8056dbbdfb8b0187c0ffe7ee3a58f
   languageName: node
   linkType: hard
 
@@ -4491,7 +4499,6 @@ __metadata:
     "@fortawesome/fontawesome-svg-core": "npm:^6.7.2"
     "@fortawesome/react-fontawesome": "npm:^0.2.2"
     "@headlessui/react": "npm:^2.2.1"
-    "@stylistic/eslint-plugin-js": "npm:^4.2.0"
     "@tailwindcss/vite": "npm:^4.2.4"
     "@testing-library/dom": "npm:^10.4.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
@@ -4504,10 +4511,12 @@ __metadata:
     "@vitejs/plugin-react": "npm:^6.0.1"
     "@vitest/coverage-v8": "npm:^4.1.5"
     eslint: "npm:^9.24.0"
+    eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
     eslint-plugin-react: "npm:^7.37.5"
     eslint-plugin-react-hooks: "npm:^5.2.0"
     globals: "npm:^16.0.0"
+    husky: "npm:^9.1.7"
     jsdom: "npm:^29.1.0"
     lodash: "npm:^4.17.21"
     prettier: "npm:^3.5.3"


### PR DESCRIPTION
## Summary

- Replaces custom `.prettierrc` rules with `{}` (Prettier defaults — double quotes, 80-char print width); reformats all source files accordingly
- Adds `eslint-config-prettier` to silence ESLint rules that overlap with Prettier; removes the now-unused `@stylistic/eslint-plugin-js` package and the formatting rules (`indent`, `semi`, `object-curly-spacing`, `jsx-quotes`) from `eslint.config.mjs`
- Adds Husky with a pre-commit hook that runs `prettier --check`, `eslint src`, `tsc -b`, and `vitest --run`
- Adds `format` / `format:check` scripts to `package.json` and a `format:check` step to the CI workflow
- Updates CLAUDE.md and README.md to document the new scripts and pre-commit hook

## Test plan

- [ ] CI passes (format:check → lint → build → coverage)
- [ ] `yarn format:check` exits 0 locally
- [ ] `yarn lint` exits 0 locally
- [ ] `yarn test:run` — 83/83 tests pass
- [ ] Make a test commit to confirm the pre-commit hook fires and blocks on a format violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)